### PR TITLE
Ref: Functional url への対応

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: deploy
+.PHONY: deploy-image update-lambda-% test ecr-login
 include .env
 
 DATE := $(shell date +%Y%m%d%H%M%S)
@@ -7,8 +7,8 @@ deploy-image: test
 	docker tag inoxee/goexpenses:latest $(AWS_ECR_REPOSITORY_URL):$(DATE)
 	docker push $(AWS_ECR_REPOSITORY_URL):$(DATE)
 
-update-lambda:
-	aws lambda update-function-code --function-name goexpenses-slackbot --image-uri $(AWS_ECR_REPOSITORY_URL):latest
+update-lambda-%:
+	aws lambda update-function-code --function-name goexpenses-slackbot --image-uri $(AWS_ECR_REPOSITORY_URL):${@:update-lambda-%=%}
 
 test:
 	go test -v

--- a/main.go
+++ b/main.go
@@ -7,10 +7,10 @@ import (
 	"github.com/aws/aws-lambda-go/lambda"
 )
 
-func handler(ctx context.Context, event events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	response := events.APIGatewayProxyResponse{
+func handler(ctx context.Context, event events.LambdaFunctionURLRequest) (events.LambdaFunctionURLResponse, error) {
+	response := events.LambdaFunctionURLResponse{
 		StatusCode: 200,
-		Body:       "\"Hello from Lambda!\"",
+		Body:       "\"Hello from Lambda!\"" + event.Body + event.RawPath + "hogehoge",
 	}
 	return response, nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -10,10 +10,10 @@ import (
 func TestHandler(t *testing.T) {
 	t.Run("TestHandler", func(t *testing.T) {
 		ctx := context.Background()
-		request := events.APIGatewayProxyRequest{}
-		expectedResponse := events.APIGatewayProxyResponse{
+		request := events.LambdaFunctionURLRequest{}
+		expectedResponse := events.LambdaFunctionURLResponse{
 			StatusCode: 200,
-			Body:       "\"Hello from Lambda!\"",
+			Body:       "\"Hello from Lambda!\"hogehoge",
 		}
 
 		response, err := handler(ctx, request)


### PR DESCRIPTION
# 概要

close

## 詳細

- Labda に 2022/04 に追加された「関数URL」を用いて関数を呼び出すつもり
    - API Gateway の設定面倒くさいからね
- 一方、slack app は health check 用のエンドポイントを要求してくるので、なんちゃってルーティングをする必要がある
- よくよく調べたら、handler に渡す引数の型が違ったので修正。events.rawPath でパスを取ってこれるようになった
